### PR TITLE
style(docs): 修复docs文档站点favicon图标未显示的问题 (#13)

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -35,8 +35,8 @@ export const shared = defineConfig({
 
 	/* prettier-ignore */
 	head: [
-		["link", { rel: "icon", type: "image/svg+xml", href: "/logo.svg" }],
-		["link", { rel: "icon", type: "image/png", href: "/logo.png" }],
+		["link", { rel: "icon", type: "image/svg+xml", href: "./logo.svg" }],
+		["link", { rel: "icon", type: "image/png", href: "./logo.png" }],
 		["meta", { name: "theme-color", content: "#5f67ee" }],
 		["meta", { property: "og:type", content: "website" }],
 		["meta", { property: "og:locale", content: "en" }],


### PR DESCRIPTION
文档站点base配置是"/react-antd-admin/docs/"，将icon的href使用基于base的相对路径，解决图标url不正确的问题